### PR TITLE
Swap hi_min to 0.2 and add aicenmin=1.e-5

### DIFF
--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -1086,6 +1086,7 @@
          first_ice    ! For bgc tracers.  Set to true if zapping ice
 
       ! local variables
+      real (kind=dbl_kind) :: aicenmin = 1.0e-5 ! Cutoff concentration for zapping
 
       integer (kind=int_kind) :: &
          n, k, it, & !counting indices
@@ -1113,7 +1114,7 @@
             call icepack_warnings_add(subname//' Zap ice: negative ice area')
             return
          elseif (abs(aicen(n)) /= c0 .and. &
-                 abs(aicen(n)) <= puny) then
+                 abs(aicen(n)) <= aicenmin) then
 
       !-----------------------------------------------------------------
       ! Account for tracers important for conservation
@@ -1657,7 +1658,7 @@
       b2 = c3         ! thickness for which participation function is small (m)
       b3 = max(rncat*(rncat-1), c2*b2/b1)
 
-      hi_min = p01    ! minimum ice thickness allowed (m) for thermo
+      hi_min = p2    ! minimum ice thickness allowed (m) for thermo
                       ! note hi_min is reset to 0.1 for kitd=0, below
 
       !-----------------------------------------------------------------
@@ -1714,7 +1715,6 @@
 #ifndef CESMCOUPLED
             hi_min = p1    ! minimum ice thickness allowed (m) for thermo
 #endif
-            hi_min =  p2
             cc1 = max(1.1_dbl_kind/rncat,hi_min)
             cc2 = c25*cc1
             cc3 = 2.25_dbl_kind


### PR DESCRIPTION
This PR adjusts parameters for the minimum ice thicknesses and concentrations allowed by Icepack. The changes are based to the discussion in https://github.com/ACCESS-NRI/dev_coupling/issues/45#issuecomment-2499959003. 

The first change, following @ofa001's recommendation, is to increase the threshold concentration for zapping from `puny` to `1.0e-5`, matching the value in CM2.

The second change is to move where `hi_min=p2` is set. It was originally set in an `if/else` block which was only activated for `kitd != 1`. In our current setup, we have `kitd = 1`, and so the `hi_min` setting didn't come into effect.

I haven't replicated the more complex way CM2 sets `aicenmin`, which swaps the value depending on whether the zero-layer scheme is used. I wasn't sure whether copying that would be useful for us or if it would just add unnecessary complexity. 

[More recent versions](https://github.com/ACCESS-NRI/Icepack/commit/8fad768ce400536904f376376e91c698a82882ba#diff-c1060d72406554f9926da46d1739db6f922fab084bde27d1d6843b2451fc9e17) of Icepack move `hi_min` to `icepack_parameters` (and might let it be set by namelist), and so we will likely have to adjust these changes when we update the version.
