### PR TITLE
Set minimum ice thickness hi_min to 0.1

### DIFF
--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -1658,7 +1658,7 @@
       b2 = c3         ! thickness for which participation function is small (m)
       b3 = max(rncat*(rncat-1), c2*b2/b1)
 
-      hi_min = p2    ! minimum ice thickness allowed (m) for thermo
+      hi_min = p1    ! minimum ice thickness allowed (m) for thermo
                       ! note hi_min is reset to 0.1 for kitd=0, below
 
       !-----------------------------------------------------------------


### PR DESCRIPTION
Following the discussion [here](https://github.com/ACCESS-NRI/dev_coupling/issues/45), we decided to reduce `hi_min` in both the UM and CICE from 0.2 to 0.1, allowing for thinner ice to be present.

This PR adjusts the value, though changes will be required in the future when we update to a later version of icepack.