### PR TITLE
PR for updating icepack to version from OM3-0.4.0 (DO NOT MERGE)

### DIFF
--- a/columnphysics/icepack_flux.F90
+++ b/columnphysics/icepack_flux.F90
@@ -299,7 +299,7 @@
 
       character(len=*),parameter :: subname='(set_sfcflux)'
 
-      raicen        = c1 !/ aicen
+      raicen        = c1 / aicen
 
 #ifdef CICE_IN_NEMO
 !----------------------------------------------------------------------

--- a/columnphysics/icepack_flux.F90
+++ b/columnphysics/icepack_flux.F90
@@ -299,7 +299,7 @@
 
       character(len=*),parameter :: subname='(set_sfcflux)'
 
-      raicen        = c1 / aicen
+      raicen        = c1 !/ aicen
 
 #ifdef CICE_IN_NEMO
 !----------------------------------------------------------------------

--- a/columnphysics/icepack_flux.F90
+++ b/columnphysics/icepack_flux.F90
@@ -299,7 +299,7 @@
 
       character(len=*),parameter :: subname='(set_sfcflux)'
 
-      raicen        = c1
+      raicen        = c1 / aicen
 
 #ifdef CICE_IN_NEMO
 !----------------------------------------------------------------------

--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -26,7 +26,7 @@
       module icepack_itd
 
       use icepack_kinds
-      use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny
+      use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny, p2
       use icepack_parameters, only: Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, rhoi
       use icepack_parameters, only: rhosi, sk_l, hs_ssl, min_salin, rsnw_fall, rhosnew
       use icepack_tracers,    only: ncat, nilyr, nslyr, nblyr, ntrcr, nbtrcr, n_aero

--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -1080,7 +1080,7 @@
             call icepack_warnings_add(subname//' Zap ice: negative ice area')
             return
          elseif (abs(aicen(n)) /= c0 .and. &
-                 abs(aicen(n)) <= 1.0e-2_dbl_kind) then
+                 abs(aicen(n)) <= puny) then
 
       !-----------------------------------------------------------------
       ! Account for tracers important for conservation

--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -26,7 +26,7 @@
       module icepack_itd
 
       use icepack_kinds
-      use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny, p2
+      use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny
       use icepack_parameters, only: Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, rhoi
       use icepack_parameters, only: rhosi, sk_l, hs_ssl, min_salin, rsnw_fall, rhosnew
       use icepack_tracers,    only: ncat, nilyr, nslyr, nblyr, ntrcr, nbtrcr, n_aero

--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -1053,6 +1053,7 @@
          first_ice    ! For bgc tracers.  Set to true if zapping ice
 
       ! local variables
+      real (kind=dbl_kind) :: aicenmin = 1.0e-5 ! Cutoff concentration for zapping
 
       integer (kind=int_kind) :: &
          n, k, it, & !counting indices
@@ -1080,7 +1081,7 @@
             call icepack_warnings_add(subname//' Zap ice: negative ice area')
             return
          elseif (abs(aicen(n)) /= c0 .and. &
-                 abs(aicen(n)) <= puny) then
+                 abs(aicen(n)) <= aicenmin) then
 
       !-----------------------------------------------------------------
       ! Account for tracers important for conservation

--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -1080,7 +1080,7 @@
             call icepack_warnings_add(subname//' Zap ice: negative ice area')
             return
          elseif (abs(aicen(n)) /= c0 .and. &
-                 abs(aicen(n)) <= puny) then
+                 abs(aicen(n)) <= 1.0e-2_dbl_kind) then
 
       !-----------------------------------------------------------------
       ! Account for tracers important for conservation

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -131,7 +131,7 @@
          dSin0_frazil = c3            ,&! bulk salinity reduction of newly formed frazil
          dts_b     = 50._dbl_kind     ,&! zsalinity timestep
          ustar_min = 0.005_dbl_kind   ,&! minimum friction velocity for ocean heat flux (m/s)
-         hi_min    = p01              ,&! minimum ice thickness allowed (m) for thermo
+         hi_min    = p1               ,&! minimum ice thickness allowed (m) for thermo
          ! mushy thermo
          a_rapid_mode      =  0.5e-3_dbl_kind,&! channel radius for rapid drainage mode (m)
          Rac_rapid_mode    =    10.0_dbl_kind,&! critical Rayleigh number

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -120,7 +120,7 @@
          kice      = 2.03_dbl_kind    ,&! thermal conductivity of fresh ice(W/m/deg)
                                         ! kice is only used with ktherm=1 (BL99) and conduct='MU71'
          ksno      = 0.30_dbl_kind    ,&! thermal conductivity of snow  (W/m/deg)
-         hs_min    = 1.e-4_dbl_kind   ,&! min snow thickness for computing zTsn (m)
+         hs_min    = 0.10_dbl_kind    ,&! min snow thickness for computing zTsn (m)
          snowpatch = 0.02_dbl_kind    ,&! parameter for fractional snow area (m)
          saltmax   = 3.2_dbl_kind     ,&! max salinity at ice base for BL99 (ppt)
                                         ! phi_init, dSin0_frazil are for mushy thermo

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -746,109 +746,145 @@
          write(warnstr,*) subname, 'Thermo iteration does not converge,'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Ice thickness:',  hilyr*nilyr
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Snow thickness:', hslyr*nslyr
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'dTsf, Tsf_errmax:',dTsf_prev, &
               Tsf_errmax
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Tsf:', Tsf
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'fsurf:', fsurfn
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'fcondtop, fcondbot, fswint', &
               fcondtopn, fcondbot, fswint
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'fswsfc', fswsfc
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Iswabs',(Iswabs(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Flux conservation error =', ferr
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Initial snow temperatures:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (Tsn_init(k),k=1,nslyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Initial ice temperatures:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (Tin_init(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Matrix ice temperature diff:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (dTmat(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'dqmat*hilyr/dt:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (hilyr*dqmat(k)/dt,k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Final snow temperatures:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (zTsn(k),k=1,nslyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Matrix ice temperature diff:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (dTmat(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'dqmat*hilyr/dt:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (hilyr*dqmat(k)/dt,k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Final ice temperatures:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (zTin(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         
          write(warnstr,*) subname, 'Ice melting temperatures:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (Tmlts(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'Ice bottom temperature:', Tbot
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'dT initial:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (Tmlts(k)-Tin_init(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'dT final:'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (Tmlts(k)-zTin(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, 'zSin'
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          write(warnstr,*) subname, (zSin(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
          call icepack_warnings_add(subname//" temperature_changes: Thermo iteration does not converge" )
          return

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -568,15 +568,15 @@
                   ! go into the ocean
                   ! This is done to avoid an 'infinite loop' whereby temp continually evolves
                   ! to the same point above zero, is reset, ad infinitum
-                  ! if (l_snow .AND. k == 1) then
-                  !    if (Top_T_was_reset_last_time) then
-                  !       fcondtopn_reduction = fcondtopn_reduction + dqmat_sn*hslyr / dt
-                  !       Top_T_was_reset_last_time = .false.
-                  !       e_num = e_num + hslyr * dqmat_sn		
-                  !    else
-                  !       Top_T_was_reset_last_time = .true.
-                  !    endif
-                  ! endif
+                  if (l_snow .AND. k == 1) then
+                     if (Top_T_was_reset_last_time) then
+                        fcondtopn_reduction = fcondtopn_reduction + dqmat_sn*hslyr / dt
+                        Top_T_was_reset_last_time = .false.
+                        e_num = e_num + hslyr * dqmat_sn		
+                     else
+                        Top_T_was_reset_last_time = .true.
+                     endif
+                  endif
                   
                   zTsn(k) = min(zTsn(k), c0)
                
@@ -713,7 +713,7 @@
                        (zTin(nilyr) - Tbot)
 
             ! Flux extra energy out of the ice
-            fcondbot = fcondbot + einex/dt
+            ! fcondbot = fcondbot + einex/dt
 
             ferr = abs( (enew-einit+e_num)/dt &
                  - (fcondtopn - fcondbot + fswint) )

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -12,6 +12,7 @@
       module icepack_therm_bl99
 
       use icepack_kinds
+      use ESMF
       use icepack_parameters, only: c0, c1, c2, p1, p5, puny
       use icepack_parameters, only: rhoi, rhos, hs_min, cp_ice, cp_ocn, depressT, Lfresh, ksno, kice
       use icepack_parameters, only: conduct, calc_Tsfc
@@ -67,7 +68,7 @@
                                       fsensn,   flatn,    &
                                       flwoutn,  fsurfn,   &
                                       fcondtopn,fcondbot, &
-                                      einit               )
+                                      einit, e_num)
 
       real (kind=dbl_kind), intent(in) :: &
          dt              ! time step
@@ -119,7 +120,9 @@
       real (kind=dbl_kind), dimension (nslyr), intent(inout) :: &
          zqsn        , & ! snow layer enthalpy (J m-3)
          zTsn            ! internal snow layer temperatures
-
+      
+      real (kind=dbl_kind), intent(out):: &
+         e_num
      ! local variables
 
       integer (kind=int_kind), parameter :: &
@@ -187,20 +190,24 @@
          Iswabs_tmp  , & ! energy to melt through fraction frac of layer
          Sswabs_tmp  , & ! same for snow
          dswabs      , & ! difference in swabs and swabs_tmp
-         frac
+         frac        , &
+         fcondtopn_reduction, &
+         fcondtopn_force, dqmat_sn
 
       logical (kind=log_kind) :: &
-         converged       ! = true when local solution has converged
+         converged, Top_T_was_reset_last_time ! = true when local solution has converged
 
       logical (kind=log_kind) , dimension (nilyr) :: &
-         reduce_kh       ! reduce conductivity when T exceeds Tmlt
+         reduce_kh      ! reduce conductivity when T exceeds Tmlt
 
       character(len=*),parameter :: subname='(temperature_changes)'
 
       !-----------------------------------------------------------------
       ! Initialize
       !-----------------------------------------------------------------
-
+      fcondtopn_reduction = c0
+      e_num = c0
+      Top_T_was_reset_last_time = .false.
       converged  = .false.
       l_snow     = .false.
       l_cold     = .true.
@@ -255,53 +262,56 @@
       !       has already computed fsurf.  (Unless we adjust fsurf here)
       !-----------------------------------------------------------------
 !mclaren: Should there be an if calc_Tsfc statement here then??
+      if (calc_Tsfc) then
+         if (sw_redist) then
 
-      if (sw_redist) then
+         if (solve_zsal) sw_dtemp = p1  ! lower tolerance with dynamic salinity
 
-      do k = 1, nilyr
+         do k = 1, nilyr
 
-         Iswabs_tmp = c0 ! all Iswabs is moved into fswsfc
-         if (Tin_init(k) <= Tmlts(k) - sw_dtemp) then
-            if (l_brine) then
-               ci = cp_ice - Lfresh * Tmlts(k) / (Tin_init(k)**2)
-               Iswabs_tmp = min(Iswabs(k), &
-                                sw_frac*(Tmlts(k)-Tin_init(k))*ci/dt_rhoi_hlyr)
-            else
-               ci = cp_ice
-               Iswabs_tmp = min(Iswabs(k), &
-                                sw_frac*(-Tin_init(k))*ci/dt_rhoi_hlyr)
+            Iswabs_tmp = c0 ! all Iswabs is moved into fswsfc
+            if (Tin_init(k) <= Tmlts(k) - sw_dtemp) then
+               if (l_brine) then
+                  ci = cp_ice - Lfresh * Tmlts(k) / (Tin_init(k)**2)
+                  Iswabs_tmp = min(Iswabs(k), &
+                                 sw_frac*(Tmlts(k)-Tin_init(k))*ci/dt_rhoi_hlyr)
+               else
+                  ci = cp_ice
+                  Iswabs_tmp = min(Iswabs(k), &
+                                 sw_frac*(-Tin_init(k))*ci/dt_rhoi_hlyr)
+               endif
             endif
-         endif
-         if (Iswabs_tmp < puny) Iswabs_tmp = c0
+            if (Iswabs_tmp < puny) Iswabs_tmp = c0
 
-         dswabs = min(Iswabs(k) - Iswabs_tmp, fswint)
-
-         fswsfc   = fswsfc + dswabs
-         fswint   = fswint - dswabs
-         Iswabs(k) = Iswabs_tmp
-
-      enddo
-
-      do k = 1, nslyr
-         if (l_snow) then
-
-            Sswabs_tmp = c0
-            if (Tsn_init(k) <= -sw_dtemp) then
-               Sswabs_tmp = min(Sswabs(k), &
-                                -sw_frac*Tsn_init(k)/etas(k))
-            endif
-            if (Sswabs_tmp < puny) Sswabs_tmp = c0
-
-            dswabs = min(Sswabs(k) - Sswabs_tmp, fswint)
+            dswabs = min(Iswabs(k) - Iswabs_tmp, fswint)
 
             fswsfc   = fswsfc + dswabs
             fswint   = fswint - dswabs
-            Sswabs(k) = Sswabs_tmp
+            Iswabs(k) = Iswabs_tmp
+
+         enddo
+
+         do k = 1, nslyr
+            if (l_snow) then
+
+               Sswabs_tmp = c0
+               if (Tsn_init(k) <= -sw_dtemp) then
+                  Sswabs_tmp = min(Sswabs(k), &
+                                 -sw_frac*Tsn_init(k)/etas(k))
+               endif
+               if (Sswabs_tmp < puny) Sswabs_tmp = c0
+
+               dswabs = min(Sswabs(k) - Sswabs_tmp, fswint)
+
+               fswsfc   = fswsfc + dswabs
+               fswint   = fswint - dswabs
+               Sswabs(k) = Sswabs_tmp
+
+            endif
+         enddo
 
          endif
-      enddo
-
-      endif
+      endif ! calc_Tsfc
 
       !-----------------------------------------------------------------
       ! Solve for new temperatures.
@@ -414,6 +424,7 @@
 
             else
 
+               fcondtopn_force = fcondtopn - fcondtopn_reduction
                call get_matrix_elements_know_Tsfc (          &
                                    l_snow,      Tbot,        &
                                    Tin_init,    Tsn_init,    &
@@ -422,7 +433,7 @@
                                    etai,        etas,        &
                                    sbdiag,      diag,        &
                                    spdiag,      rhs,         &
-                                   fcondtopn)
+                                   fcondtopn_force)
                if (icepack_warnings_aborted(subname)) return
 
             endif  ! calc_Tsfc
@@ -544,7 +555,32 @@
                else
                   zTsn(k) = c0
                endif
-               if (l_brine) zTsn(k) = min(zTsn(k), c0)
+               ! if (l_brine) zTsn(k) = min(zTsn(k), c0)
+               if ((l_brine) .and. zTsn(k)>c0) then
+            
+                  ! Alex West: return this energy to the ocean
+                  
+                  dqmat_sn = (zTsn(k)*cp_ice - Lfresh)*rhos - zqsn(k)
+                  
+                  ! Alex West: If this is the second time in succession that Tsn(1) has been
+                  ! reset, tell the solver to reduce the forcing at the top, and
+                  ! pass the difference to the array enum where it will eventually
+                  ! go into the ocean
+                  ! This is done to avoid an 'infinite loop' whereby temp continually evolves
+                  ! to the same point above zero, is reset, ad infinitum
+                  if (l_snow .AND. k == 1) then
+                     if (Top_T_was_reset_last_time) then
+                        fcondtopn_reduction = fcondtopn_reduction + dqmat_sn*hslyr / dt
+                        Top_T_was_reset_last_time = .false.
+                        e_num = e_num + hslyr * dqmat_sn		
+                     else
+                        Top_T_was_reset_last_time = .true.
+                     endif
+                  endif
+                  
+                  zTsn(k) = min(zTsn(k), c0)
+               
+               endif
 
       !-----------------------------------------------------------------
       ! If condition 1 or 2 failed, average new snow layer
@@ -578,6 +614,16 @@
                   dTmat(k) = zTin(k) - Tmlts(k)
                   dqmat(k) = rhoi * dTmat(k) &
                            * (cp_ice - Lfresh * Tmlts(k)/zTin(k)**2)
+
+                  if ((.not. l_snow) .and. (k == 1)) then
+                     if (Top_T_was_reset_last_time) then
+                        fcondtopn_reduction = fcondtopn_reduction + dqmat(k)*hilyr / dt
+                        Top_T_was_reset_last_time = .false.
+                        e_num = e_num + hilyr * dqmat(k)
+                     else
+                        Top_T_was_reset_last_time = .true.
+                     endif
+                  endif
 ! use this for the case that Tmlt changes by an amount dTmlt=Tmltnew-Tmlt(k)
 !                             + rhoi * dTmlt &
 !                             * (cp_ocn - cp_ice + Lfresh/zTin(k))
@@ -669,11 +715,11 @@
             ! Flux extra energy out of the ice
             fcondbot = fcondbot + einex/dt
 
-            ferr = abs( (enew-einit)/dt &
+            ferr = abs( (enew-einit+e_num)/dt &
                  - (fcondtopn - fcondbot + fswint) )
 
             ! factor of 0.9 allows for roundoff errors later
-            if (ferr > 0.9_dbl_kind*ferrmax) then         ! condition (5)
+            if (ferr > 0.9_dbl_kind*ferrmax*0.05_dbl_kind) then         ! condition (5)
 
                converged = .false.
 
@@ -699,76 +745,110 @@
       if (.not.converged) then
          write(warnstr,*) subname, 'Thermo iteration does not converge,'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Ice thickness:',  hilyr*nilyr
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Snow thickness:', hslyr*nslyr
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'dTsf, Tsf_errmax:',dTsf_prev, &
               Tsf_errmax
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Tsf:', Tsf
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'fsurf:', fsurfn
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'fcondtop, fcondbot, fswint', &
               fcondtopn, fcondbot, fswint
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'fswsfc', fswsfc
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Iswabs',(Iswabs(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Flux conservation error =', ferr
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Initial snow temperatures:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (Tsn_init(k),k=1,nslyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Initial ice temperatures:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (Tin_init(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Matrix ice temperature diff:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (dTmat(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'dqmat*hilyr/dt:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (hilyr*dqmat(k)/dt,k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Final snow temperatures:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (zTsn(k),k=1,nslyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Matrix ice temperature diff:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (dTmat(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'dqmat*hilyr/dt:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (hilyr*dqmat(k)/dt,k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Final ice temperatures:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (zTin(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
          write(warnstr,*) subname, 'Ice melting temperatures:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (Tmlts(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Ice bottom temperature:', Tbot
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'dT initial:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (Tmlts(k)-Tin_init(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'dT final:'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (Tmlts(k)-zTin(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'zSin'
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, (zSin(k),k=1,nilyr)
          call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
          call icepack_warnings_add(subname//" temperature_changes: Thermo iteration does not converge" )
          return

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -885,6 +885,10 @@
          call icepack_warnings_add(warnstr)
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
 
+         write(warnstr,*) subname, 'enum:', e_num
+         call icepack_warnings_add(warnstr)
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+
          call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
          call icepack_warnings_add(subname//" temperature_changes: Thermo iteration does not converge" )
          return

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -568,15 +568,15 @@
                   ! go into the ocean
                   ! This is done to avoid an 'infinite loop' whereby temp continually evolves
                   ! to the same point above zero, is reset, ad infinitum
-                  if (l_snow .AND. k == 1) then
-                     if (Top_T_was_reset_last_time) then
-                        fcondtopn_reduction = fcondtopn_reduction + dqmat_sn*hslyr / dt
-                        Top_T_was_reset_last_time = .false.
-                        e_num = e_num + hslyr * dqmat_sn		
-                     else
-                        Top_T_was_reset_last_time = .true.
-                     endif
-                  endif
+                  ! if (l_snow .AND. k == 1) then
+                  !    if (Top_T_was_reset_last_time) then
+                  !       fcondtopn_reduction = fcondtopn_reduction + dqmat_sn*hslyr / dt
+                  !       Top_T_was_reset_last_time = .false.
+                  !       e_num = e_num + hslyr * dqmat_sn		
+                  !    else
+                  !       Top_T_was_reset_last_time = .true.
+                  !    endif
+                  ! endif
                   
                   zTsn(k) = min(zTsn(k), c0)
                
@@ -713,7 +713,7 @@
                        (zTin(nilyr) - Tbot)
 
             ! Flux extra energy out of the ice
-            ! fcondbot = fcondbot + einex/dt
+            fcondbot = fcondbot + einex/dt
 
             ferr = abs( (enew-einit+e_num)/dt &
                  - (fcondtopn - fcondbot + fswint) )

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -713,7 +713,7 @@
                        (zTin(nilyr) - Tbot)
 
             ! Flux extra energy out of the ice
-            fcondbot = fcondbot + einex/dt
+            ! fcondbot = fcondbot + einex/dt
 
             ferr = abs( (enew-einit+e_num)/dt &
                  - (fcondtopn - fcondbot + fswint) )

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -709,9 +709,6 @@
             fcondbot = kh(1+nslyr+nilyr) * &
                        (zTin(nilyr) - Tbot)
 
-            ! Flux extra energy out of the ice
-            ! fcondbot = fcondbot + einex/dt
-
             ferr = abs( (enew-einit+e_num)/dt &
                  - (fcondtopn - fcondbot + fswint) )
 

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -553,7 +553,6 @@
                else
                   zTsn(k) = c0
                endif
-               ! if (l_brine) zTsn(k) = min(zTsn(k), c0)
                if ((l_brine) .and. zTsn(k)>c0) then
             
                   ! Alex West: return this energy to the ocean

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -265,8 +265,6 @@
       if (calc_Tsfc) then
          if (sw_redist) then
 
-         if (solve_zsal) sw_dtemp = p1  ! lower tolerance with dynamic salinity
-
          do k = 1, nilyr
 
             Iswabs_tmp = c0 ! all Iswabs is moved into fswsfc

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -719,7 +719,7 @@
                  - (fcondtopn - fcondbot + fswint) )
 
             ! factor of 0.9 allows for roundoff errors later
-            if (ferr > 0.9_dbl_kind*ferrmax*0.05_dbl_kind) then         ! condition (5)
+            if (ferr > 0.9_dbl_kind*ferrmax) then         ! condition (5)
 
                converged = .false.
 

--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -39,7 +39,7 @@
                 adjust_enthalpy
 
       real (kind=dbl_kind), parameter, public :: &
-         ferrmax = 2.0e-2_dbl_kind    ! max allowed energy flux error (W m-2)
+         ferrmax = 1.0e-3_dbl_kind    ! max allowed energy flux error (W m-2)
                                       ! recommend ferrmax < 0.01 W m-2
 
       real (kind=dbl_kind), parameter, public :: &

--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -39,7 +39,7 @@
                 adjust_enthalpy
 
       real (kind=dbl_kind), parameter, public :: &
-         ferrmax = 1.0e-3_dbl_kind    ! max allowed energy flux error (W m-2)
+         ferrmax = 2.0e-2_dbl_kind    ! max allowed energy flux error (W m-2)
                                       ! recommend ferrmax < 0.01 W m-2
 
       real (kind=dbl_kind), parameter, public :: &

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -88,7 +88,7 @@
          
          real (kind=dbl_kind)   :: fcondtopn_solve
 
-         real (kind=dbl_kind), parameter :: ratio_Wm2_m = 800.0, cold_temp_flag = c0 - 60.0
+         real (kind=dbl_kind), parameter :: ratio_Wm2_m = 1000.0, cold_temp_flag = c0 - 60.0
    
          ! AEW: New variables for cold-ice flux capping
          real (kind=dbl_kind) :: top_layer_temp,     &

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -2080,6 +2080,7 @@
          write(warnstr,*) subname, fbot,fcondbotn
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          call ESMF_LogWrite("----------------------------\n\n", ESMF_LOGMSG_INFO)
+         call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
       end if
 
       ! if (ferr > 1.1_dbl_kind*ferrmax) then

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -2047,7 +2047,7 @@
       ! end if
       
       if (ferr > 10.0_dbl_kind*ferrmax) then
-         
+         call ESMF_LogWrite("\n\n----------------------------", ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Thermo energy conservation error'
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Flux error (W/m^2) =', ferr
@@ -2066,6 +2066,10 @@
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Input energy =', einp
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'fcondtopn =', fcondtopn
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'Intermediate energy =', einter
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'Numerical energy =', e_num
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, 'fcondtopn_extra energy =', fcondtopn_extra
@@ -2074,6 +2078,7 @@
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
          write(warnstr,*) subname, fbot,fcondbotn
          call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         call ESMF_LogWrite("----------------------------\n\n", ESMF_LOGMSG_INFO)
       end if
 
       ! if (ferr > 1.1_dbl_kind*ferrmax) then

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -286,7 +286,7 @@
          fadvocn, saltvol, dfsalt ! advective heat flux to ocean
 
       real (kind=dbl_kind) :: &
-         fcondtopn_solve, fcondtopn_extra, e_num, fsurfn_solve
+         fcondtopn_solve, fcondtopn_extra, e_num
 
       character(len=*),parameter :: subname='(thermo_vertical)'
 
@@ -382,7 +382,6 @@
          else ! ktherm
             fcondtopn_solve = cap_conductive_flux(nilyr, nslyr, fcondtopn, hin, zTsn, zTin, hslyr)
             fcondtopn_extra = fcondtopn - fcondtopn_solve
-            fsurfn_solve = fsurfn - fcondtopn_extra
 
             ! if (calc_Tsfc) then
             !    fcondtopn = fcondtopn_solve
@@ -400,7 +399,7 @@
                                      zSin,                 &
                                      Tsf,       Tbot,      &
                                      fsensn,    flatn,     &
-                                     flwoutn,   fsurfn_solve,    &
+                                     flwoutn,   fsurfn,    &
                                      fcondtopn_solve, fcondbotn,  &
                                      einit, e_num)
             if (icepack_warnings_aborted(subname)) return

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -286,7 +286,7 @@
          fadvocn, saltvol, dfsalt ! advective heat flux to ocean
 
       real (kind=dbl_kind) :: &
-         fcondtopn_solve, fcondtopn_extra, e_num
+         fcondtopn_solve, fcondtopn_extra, e_num, fsurfn_solve
 
       character(len=*),parameter :: subname='(thermo_vertical)'
 
@@ -382,6 +382,7 @@
          else ! ktherm
             fcondtopn_solve = cap_conductive_flux(nilyr, nslyr, fcondtopn, hin, zTsn, zTin, hslyr)
             fcondtopn_extra = fcondtopn - fcondtopn_solve
+            fsurfn_solve = fsurfn - fcondtopn_extra
 
             ! if (calc_Tsfc) then
             !    fcondtopn = fcondtopn_solve
@@ -399,7 +400,7 @@
                                      zSin,                 &
                                      Tsf,       Tbot,      &
                                      fsensn,    flatn,     &
-                                     flwoutn,   fsurfn,    &
+                                     flwoutn,   fsurfn_solve,    &
                                      fcondtopn_solve, fcondbotn,  &
                                      einit, e_num)
             if (icepack_warnings_aborted(subname)) return

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -380,8 +380,8 @@
             if (icepack_warnings_aborted(subname)) return
 
          else ! ktherm
-            ! fcondtopn_solve = cap_conductive_flux(nilyr, nslyr, fcondtopn, hin, zTsn, zTin, hslyr)
-            ! fcondtopn_extra = fcondtopn - fcondtopn_solve
+            fcondtopn_solve = cap_conductive_flux(nilyr, nslyr, fcondtopn, hin, zTsn, zTin, hslyr)
+            fcondtopn_extra = fcondtopn - fcondtopn_solve
 
             ! if (calc_Tsfc) then
             !    fcondtopn = fcondtopn_solve
@@ -400,7 +400,7 @@
                                      Tsf,       Tbot,      &
                                      fsensn,    flatn,     &
                                      flwoutn,   fsurfn,    &
-                                     fcondtopn, fcondbotn,  &
+                                     fcondtopn_solve, fcondbotn,  &
                                      einit, e_num)
             if (icepack_warnings_aborted(subname)) return
 

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -380,8 +380,8 @@
             if (icepack_warnings_aborted(subname)) return
 
          else ! ktherm
-            fcondtopn_solve = cap_conductive_flux(nilyr, nslyr, fcondtopn, hin, zTsn, zTin, hslyr)
-            fcondtopn_extra = fcondtopn - fcondtopn_solve
+            ! fcondtopn_solve = cap_conductive_flux(nilyr, nslyr, fcondtopn, hin, zTsn, zTin, hslyr)
+            ! fcondtopn_extra = fcondtopn - fcondtopn_solve
 
             ! if (calc_Tsfc) then
             !    fcondtopn = fcondtopn_solve
@@ -400,7 +400,7 @@
                                      Tsf,       Tbot,      &
                                      fsensn,    flatn,     &
                                      flwoutn,   fsurfn,    &
-                                     fcondtopn_solve, fcondbotn,  &
+                                     fcondtopn, fcondbotn,  &
                                      einit, e_num)
             if (icepack_warnings_aborted(subname)) return
 
@@ -448,7 +448,7 @@
                              smliq,       massliq,   &
                              fbot,        Tbot,      &
                              flatn,       fsurfn,    &
-                             fcondtopn_solve,   fcondbotn, &
+                             fcondtopn,   fcondbotn, &
                              fsnow,       hsn_new,   &
                              fhocnn,      evapn,     &
                              evapsn,      evapin,    &

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -62,6 +62,8 @@
       use icepack_meltpond_topo, only: compute_ponds_topo
       use icepack_snow, only: drain_snow
 
+      use ESMF
+
       implicit none
 
       private
@@ -72,6 +74,49 @@
       contains
 
 !=======================================================================
+
+      function cap_conductive_flux(nilyr, nslyr, fcondtopn, hin, zTsn, zTin, hslyr) result(fcondtopn_solve)
+         
+         integer (kind=int_kind), intent(in) :: &
+            nilyr   , & ! number of ice layers
+            nslyr       ! number of snow layers
+         real (kind=dbl_kind), intent(in)    :: fcondtopn
+         real (kind=dbl_kind), intent(in)    :: hin
+         real (kind=dbl_kind), intent(in)    :: zTin(nilyr)
+         real (kind=dbl_kind), intent(in)    :: zTsn(nslyr)
+         real (kind=dbl_kind), intent(in)    :: hslyr
+         
+         real (kind=dbl_kind)   :: fcondtopn_solve
+
+         real (kind=dbl_kind), parameter :: ratio_Wm2_m = 1000.0, cold_temp_flag = c0 - 60.0
+   
+         ! AEW: New variables for cold-ice flux capping
+         real (kind=dbl_kind) :: top_layer_temp,     &
+                  reduce_ratio,       &
+                  reduce_amount
+                  
+         
+         if (abs(fcondtopn) > ratio_Wm2_m * hin) then
+            fcondtopn_solve = sign(ratio_Wm2_m * hin,fcondtopn)
+            
+         else
+            fcondtopn_solve = fcondtopn
+         endif
+   
+         if (hslyr>hs_min) then
+            top_layer_temp = zTsn(1)
+         else
+            top_layer_temp = zTin(1)
+         endif
+   
+         if ((top_layer_temp < cold_temp_flag) .and. (fcondtopn_solve < c0)) then
+            reduce_ratio = (cold_temp_flag - top_layer_temp) / (100.0 + cold_temp_flag)
+            reduce_amount = reduce_ratio * fcondtopn_solve
+            fcondtopn_solve = fcondtopn_solve - reduce_amount
+         endif
+   
+      end function cap_conductive_flux
+
 !
 ! Driver for updating ice and snow internal temperatures and
 ! computing thermodynamic growth rates and atmospheric fluxes.
@@ -240,6 +285,9 @@
       real (kind=dbl_kind) :: &
          fadvocn, saltvol, dfsalt ! advective heat flux to ocean
 
+      real (kind=dbl_kind) :: &
+         fcondtopn_solve, fcondtopn_extra, e_num
+
       character(len=*),parameter :: subname='(thermo_vertical)'
 
       !-----------------------------------------------------------------
@@ -266,6 +314,8 @@
       meltsliq= c0
       massice(:) = c0
       massliq(:) = c0
+      e_num = c0
+      fcondtopn_extra = c0
 
       if (calc_Tsfc) then
          fsensn  = c0
@@ -273,6 +323,8 @@
          fsurfn    = c0
          fcondtopn = c0
       endif
+
+      fcondtopn_solve = fcondtopn
 
       !-----------------------------------------------------------------
       ! Compute variables needed for vertical thermo calculation
@@ -328,6 +380,12 @@
             if (icepack_warnings_aborted(subname)) return
 
          else ! ktherm
+            fcondtopn_solve = cap_conductive_flux(nilyr, nslyr, fcondtopn, hin, zTsn, zTin, hslyr)
+            fcondtopn_extra = fcondtopn - fcondtopn_solve
+
+            ! if (calc_Tsfc) then
+            !    fcondtopn = fcondtopn_solve
+            ! end if
 
             call temperature_changes(dt,                   &
                                      rhoa,      flw,       &
@@ -342,8 +400,8 @@
                                      Tsf,       Tbot,      &
                                      fsensn,    flatn,     &
                                      flwoutn,   fsurfn,    &
-                                     fcondtopn, fcondbotn,  &
-                                     einit                 )
+                                     fcondtopn_solve, fcondbotn,  &
+                                     einit, e_num)
             if (icepack_warnings_aborted(subname)) return
 
          endif ! ktherm
@@ -390,7 +448,7 @@
                              smliq,       massliq,   &
                              fbot,        Tbot,      &
                              flatn,       fsurfn,    &
-                             fcondtopn,   fcondbotn, &
+                             fcondtopn_solve,   fcondbotn, &
                              fsnow,       hsn_new,   &
                              fhocnn,      evapn,     &
                              evapsn,      evapin,    &
@@ -401,7 +459,8 @@
                              mlt_onset,   frz_onset, &
                              zSin,        sss,       &
                              sst,                    &
-                             dsnow,       rsnw)
+                             dsnow,       rsnw,      &
+                             e_num, fcondtopn_extra  )
       if (icepack_warnings_aborted(subname)) return
 
       !-----------------------------------------------------------------
@@ -415,7 +474,7 @@
                                       fsnow,     einit,    &
                                       einter,    efinal,   &
                                       fcondtopn, fcondbotn, &
-                                      fadvocn,   fbot      )
+                                      fadvocn,   fbot, e_num, fcondtopn_extra )
       if (icepack_warnings_aborted(subname)) return
 
       !-----------------------------------------------------------------
@@ -1059,8 +1118,9 @@
                                     congel,    snoice,   &
                                     mlt_onset, frz_onset,&
                                     zSin,      sss,      &
-                                    sst,                 &
-                                    dsnow,     rsnw)
+                                    sst,                 &                                    
+                                    dsnow,     rsnw,     &
+                                    e_num, fcondtopn_extra)
 
       real (kind=dbl_kind), intent(in) :: &
          dt          , & ! time step
@@ -1127,7 +1187,9 @@
       real (kind=dbl_kind), intent(in) :: &
          sst         , & ! sea surface temperature (C)
          sss             ! ocean salinity (PSU)
-
+      
+      real (kind=dbl_kind), intent(in) :: &
+         e_num, fcondtopn_extra
       ! local variables
 
       integer (kind=int_kind) :: &
@@ -1259,7 +1321,8 @@
       wk1 = (fsurfn - fcondtopn) * dt
       etop_mlt = max(wk1, c0)           ! etop_mlt > 0
 
-      wk1 = (fcondbotn - fbot) * dt
+      wk1 = (fcondbotn - fbot + fcondtopn_extra) * dt
+      ! wk1 = (fcondbotn - fbot) * dt
       ebot_mlt = max(wk1, c0)           ! ebot_mlt > 0
       ebot_gro = min(wk1, c0)           ! ebot_gro < 0
 
@@ -1511,8 +1574,8 @@
       ! fhocn is the available ocean heat that is left after use by ice
       !-----------------------------------------------------------------
 
-      fhocnn = fbot &
-             + (esub + etop_mlt + ebot_mlt)/dt
+      fhocnn = fbot + (esub + etop_mlt + ebot_mlt + e_num)/dt
+      ! fhocnn = fbot + (esub + etop_mlt + ebot_mlt)/dt
 
     !-----------------------------------------------------------------
     ! Add new snowfall at top surface
@@ -1934,7 +1997,7 @@
                                             einit,    einter,   &
                                             efinal,             &
                                             fcondtopn,fcondbotn, &
-                                            fadvocn,  fbot      )
+                                            fadvocn,  fbot, e_num, fcondtopn_extra)
 
       real (kind=dbl_kind), intent(in) :: &
          dt              ! time step
@@ -1947,7 +2010,7 @@
          fsnow       , & ! snowfall rate (kg m-2 s-1)
          fcondtopn   , &
          fadvocn     , &
-         fbot
+         fbot, e_num, fcondtopn_extra
 
       real (kind=dbl_kind), intent(in) :: &
          einit       , & ! initial energy of melting (J m-2)
@@ -1960,7 +2023,7 @@
       real (kind=dbl_kind) :: &
          einp        , & ! energy input during timestep (J m-2)
          ferr            ! energy conservation error (W m-2)
-
+      
       character(len=*),parameter :: subname='(conservation_check_vthermo)'
 
       !----------------------------------------------------------------
@@ -1977,9 +2040,45 @@
       einp = (fsurfn - flatn + fswint - fhocnn &
            - fsnow*Lfresh - fadvocn) * dt
       ferr = abs(efinal-einit-einp) / dt
+      
+      ! if (ferr > 10.0_dbl_kind*ferrmax) then
+      !    call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
+      !    call icepack_warnings_add(subname//" conservation_check_vthermo: Thermo energy conservation error" )
+      ! end if
+      
+      if (ferr > 10.0_dbl_kind*ferrmax) then
+         
+         write(warnstr,*) subname, 'Thermo energy conservation error'
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'Flux error (W/m^2) =', ferr
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'Energy error (J) =', ferr*dt
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'Initial energy =', einit
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'Final energy   =', efinal
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'efinal - einit  =', efinal-einit
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'fsurfn,flatn,fswint,fhocn, fsnow*Lfresh:'
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, fsurfn,flatn,fswint,fhocnn, fsnow*Lfresh
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'Input energy =', einp
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'Numerical energy =', e_num
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'fcondtopn_extra energy =', fcondtopn_extra
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, 'fbot,fcondbot:'
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+         write(warnstr,*) subname, fbot,fcondbotn
+         call ESMF_LogWrite(warnstr, ESMF_LOGMSG_INFO)
+      end if
 
-      if (ferr > 1.1_dbl_kind*ferrmax) then
-         call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
+      ! if (ferr > 1.1_dbl_kind*ferrmax) then
+      if (.false.) then
+         ! call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
          call icepack_warnings_add(subname//" conservation_check_vthermo: Thermo energy conservation error" )
 
          write(warnstr,*) subname, 'Thermo energy conservation error'
@@ -1999,6 +2098,10 @@
          write(warnstr,*) subname, fsurfn,flatn,fswint,fhocnn, fsnow*Lfresh
          call icepack_warnings_add(warnstr)
          write(warnstr,*) subname, 'Input energy =', einp
+         call icepack_warnings_add(warnstr)
+         write(warnstr,*) subname, 'Numerical energy =', e_num
+         call icepack_warnings_add(warnstr)
+         write(warnstr,*) subname, 'fcondtopn_extra energy =', fcondtopn_extra
          call icepack_warnings_add(warnstr)
          write(warnstr,*) subname, 'fbot,fcondbot:'
          call icepack_warnings_add(warnstr)

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -1319,6 +1319,7 @@
       econ = min(wk1, c0)     ! energy for condensation, < 0
 
       wk1 = (fsurfn - fcondtopn) * dt
+      ! wk1 = fsurfn * dt
       etop_mlt = max(wk1, c0)           ! etop_mlt > 0
 
       wk1 = (fcondbotn - fbot + fcondtopn_extra) * dt
@@ -2795,7 +2796,6 @@
       !-----------------------------------------------------------------
       ! Vertical thermodynamics: Heat conduction, growth and melting.
       !-----------------------------------------------------------------
-
             if (.not.(calc_Tsfc)) then
 
                ! If not calculating surface temperature and fluxes, set
@@ -2805,8 +2805,8 @@
                ! hadgem routine sets fluxes to default values in ice-only mode
                call set_sfcflux(aicen      (n),                 &
                                 flatn_f    (n), fsensn_f   (n), &
-                                fcondtopn_f(n),                 &
                                 fsurfn_f   (n),                 &
+                                fcondtopn_f(n),                 &
                                 flatn      (n), fsensn     (n), &
                                 fsurfn     (n),                 &
                                 fcondtopn  (n))

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -88,7 +88,7 @@
          
          real (kind=dbl_kind)   :: fcondtopn_solve
 
-         real (kind=dbl_kind), parameter :: ratio_Wm2_m = 1000.0, cold_temp_flag = c0 - 60.0
+         real (kind=dbl_kind), parameter :: ratio_Wm2_m = 800.0, cold_temp_flag = c0 - 60.0
    
          ! AEW: New variables for cold-ice flux capping
          real (kind=dbl_kind) :: top_layer_temp,     &

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -1319,11 +1319,9 @@
       econ = min(wk1, c0)     ! energy for condensation, < 0
 
       wk1 = (fsurfn - fcondtopn) * dt
-      ! wk1 = fsurfn * dt
       etop_mlt = max(wk1, c0)           ! etop_mlt > 0
 
       wk1 = (fcondbotn - fbot + fcondtopn_extra) * dt
-      ! wk1 = (fcondbotn - fbot) * dt
       ebot_mlt = max(wk1, c0)           ! ebot_mlt > 0
       ebot_gro = min(wk1, c0)           ! ebot_gro < 0
 
@@ -1576,7 +1574,6 @@
       !-----------------------------------------------------------------
 
       fhocnn = fbot + (esub + etop_mlt + ebot_mlt + e_num)/dt
-      ! fhocnn = fbot + (esub + etop_mlt + ebot_mlt)/dt
 
     !-----------------------------------------------------------------
     ! Add new snowfall at top surface


### PR DESCRIPTION
# Not to be merged


This PR describes the changes in updating the base of CM3's icepack version from 6703bc5  to https://github.com/ACCESS-NRI/Icepack/commit/43ead56380bf11ecad66f165dcd736ed0c278763. If the changes are approved, I'll change the branch name from `update-cm3-icepack` to `cm3-coupling-0.4.0`.

This branch was created by rebasing [`cm3-coupling`](https://github.com/ACCESS-NRI/Icepack/tree/cm3-coupling) onto https://github.com/ACCESS-NRI/Icepack/commit/43ead56380bf11ecad66f165dcd736ed0c278763.

Several conflicts came up in the merge. I'll record each of the conflicts here for the purpose of documentation. For review, I've separated them into more substantial conflicts, and much more straightforward ones where I'm more confident in my choice for resolution. Where relevant, I've tried to include some background on the upstream or local changes that caused the conflicts.


## Conflicts


### Clashes more likely to need review
#### Change of `hi_min` parameter

The minimum ice thickness `hi_min` was previously set in `icepack_itd.F90`, where it was given a default value and overwritten in specific cirumstances. 

[`8fad768`](https://github.com/ACCESS-NRI/Icepack/commit/8fad768ce400536904f376376e91c698a82882ba#diff-038f9d998c813a8fe204ed47bdb6f4a7e643d60ef13f230775c4a7590c721a8e) on `main` moves its definition and default value to `icepack_parameters.F90`, making it [definable in a CICE namelist](https://github.com/ACCESS-NRI/CICE/commit/deb247bcec381615d01006bfa15dddf3a4f068fd). This includes for example the following changes in `icepack_itd.F90`:

```diff
+      use icepack_parameters, only: skl_bgc, z_tracers, hi_min
...

subroutine icepack_init_itd(hin_max)
...
-      hi_min = p01    ! minimum ice thickness allowed (m) for thermo
-                       ! note hi_min is reset to 0.1 for kitd=0, below

...

- #ifndef CESMCOUPLED
-             hi_min = p1    ! minimum ice thickness allowed (m) for thermo
- #endif
```

The following clashes between our branch and main occur in  parts of `icepack_itd.F90`:

```
<<<<<<< HEAD
=======
#ifndef CESMCOUPLED
            hi_min = p1    ! minimum ice thickness allowed (m) for thermo
#endif
            hi_min =  p2
>>>>>>> c1e1d5d (increase ice and snow thickness minimum values to match CM2, revert conductive flux limits to CM2)
```

```
<<<<<<< HEAD
=======
      hi_min = p2    ! minimum ice thickness allowed (m) for thermo
                      ! note hi_min is reset to 0.1 for kitd=0, below

>>>>>>> e4815a4 (Swap hi_min to 0.2 and add aicenmin=1.e-5)
```

```
<<<<<<< HEAD
=======
#ifndef CESMCOUPLED
            hi_min = p1    ! minimum ice thickness allowed (m) for thermo
#endif
>>>>>>> e4815a4 (Swap hi_min to 0.2 and add aicenmin=1.e-5)
```

I think it makes sense for us to pick up the changes from main. Since our CM3 coupling requires `hi_min=p1` to [match the value in the UM](https://github.com/ACCESS-NRI/dev_coupling/issues/45), we need to be careful when bringing in this change.

[I've changed the new default value](https://github.com/ACCESS-NRI/Icepack/commit/31305ce7ebd30688bfb5d6929bc09a31f89e6c67) of `hi_min` in  `icepack_parameters.F90` from `p01` be `p1` (required to match UM value), and will add a comment in the namelist warning that `hi_min=p1` is required for CM3's coupling.

--- 

### More straightforward clashes:

<details>
In `icepack_therm_bl99.F90`:

```
<<<<<<< HEAD
      do k = 1, nilyr

         Iswabs_tmp = c0 ! all Iswabs is moved into fswsfc
         if (Tin_init(k) <= Tmlts(k) - sw_dtemp) then
            if (l_brine) then
               ci = cp_ice - Lfresh * Tmlts(k) / (Tin_init(k)**2)
               Iswabs_tmp = min(Iswabs(k), &
                                sw_frac*(Tmlts(k)-Tin_init(k))*ci/dt_rhoi_hlyr)
            else
               ci = cp_ice
               Iswabs_tmp = min(Iswabs(k), &
                                sw_frac*(-Tin_init(k))*ci/dt_rhoi_hlyr)
=======
         do k = 1, nilyr

            Iswabs_tmp = c0 ! all Iswabs is moved into fswsfc
            if (Tin_init(k) <= Tmlts(k) - sw_dtemp) then
               if (l_brine) then
                  ci = cp_ice - Lfresh * Tmlts(k) / (Tin_init(k)**2)
                  Iswabs_tmp = min(Iswabs(k), &
                                 sw_frac*(Tmlts(k)-Tin_init(k))*ci/dt_rhoi_hlyr)
               else
                  ci = cp_ice
                  Iswabs_tmp = min(Iswabs(k), &
                                 sw_frac*(-Tin_init(k))*ci/dt_rhoi_hlyr)
               endif
>>>>>>> b40315a (logging, tweaked newton solver tolerances, re-add einex)
```

This is an indentation change in our `cm3-coupling` branch, added to fix the indentation under `if calc_Tsfc`.  Keep changes from `cm3-coupling`.

---

```
<<<<<<< HEAD

               call get_matrix_elements_know_Tsfc (          &
=======
               fcondtopn_force = fcondtopn - fcondtopn_reduction
               call get_matrix_elements_know_Tsfc (nilyr, nslyr, &
>>>>>>> b40315a (logging, tweaked newton solver tolerances, re-add einex)
```
[05ac0ec](https://github.com/ACCESS-NRI/Icepack/commit/05ac0ec3ea666080eed36e67f6cf8ce1255b243f#diff-e9e96763f6526e7c329b14eb4245aac7fc7c0c443349c5960c448bfb12409390) on `main` removed the `nilyr` and `nslyr` arguments to this subroutine, as they are already available from 
```fortran
use icepack_tracers, only: nilyr, nslyr
```
at the top of the module. Combine the changes from both branches resulting in:

```fortran
               fcondtopn_force = fcondtopn - fcondtopn_reduction
               call get_matrix_elements_know_Tsfc (          &
```

### icepack_therm_vertical.F90

```
<<<<<<< HEAD

      subroutine thermo_vertical (dt,          aicen,     &
=======
      subroutine thermo_vertical (nilyr,       nslyr,     &
                                  dt,          aicen,     &
>>>>>>> b40315a (logging, tweaked newton solver tolerances, re-add einex)
```
Use changes from main, which remove redundant subroutine arguments.

---
```
<<<<<<< HEAD
      massice(:) = c0
      massliq(:) = c0
=======
      e_num = c0
      fcondtopn_extra = c0
>>>>>>> b40315a (logging, tweaked newton solver tolerances, re-add einex)
```
Separate variable initialisations were added in each branch. Use both changes



```
      call thickness_changes(dt,          yday,      &
                             efinal,                 &
                             hin,         hilyr,     &
                             hsn,         hslyr,     &
                             zqin,        zqsn,      &
                             smice,       massice,   &
                             smliq,       massliq,   &
                             fbot,        Tbot,      &
                             flatn,       fsurfn,    &
                             fcondtopn_solve,   fcondbotn, &
                             fsnow,       hsn_new,   &
                             fhocnn,      evapn,     &
                             evapsn,      evapin,    &
                             meltt,       melts,     &
                             meltsliq,    frain,     &
                             meltb,                  &
                             congel,      snoice,    &
                             mlt_onset,   frz_onset, &
                             zSin,        sss,       &
<<<<<<< HEAD
                             sst,                    &
                             dsnow,       rsnw)
=======
                             dsnow,       rsnw,       &
                             e_num, fcondtopn_extra   )
>>>>>>> b40315a (logging, tweaked newton solver tolerances, re-add einex)
```

`sst` added as argument in `main` in [4c87095](https://github.com/ACCESS-NRI/Icepack/commit/4c87095256c1c599c3ccaa857a95744158751a60#diff-a6075888f8619fe2ae650ac420eb030b6c030a500f6b9bbf4643320a45aad3c1) to allow for one-step congelation formulation. `e_num`, `fcondtopn_extra` added in `cm3-coupling`. Combine both changes into

```fortran
                             sst,                    &
                             dsnow,       rsnw,      &
                             e_num, fcondtopn_extra  )
```

Same changes added further down in subroutine definition.


### icepack_itd.F90


```
<<<<<<< HEAD
      use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny
      use icepack_parameters, only: Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, rhoi
      use icepack_parameters, only: rhosi, sk_l, hs_ssl, min_salin, rsnw_fall, rhosnew
      use icepack_tracers,    only: ncat, nilyr, nslyr, nblyr, ntrcr, nbtrcr, n_aero
=======
      use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny, p2
      use icepack_parameters, only: Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, Tocnfrz, rhoi
      use icepack_parameters, only: rhosi, sk_l, hs_ssl, min_salin, rsnw_fall
>>>>>>> c1e1d5d (increase ice and snow thickness minimum values to match CM2, revert conductive flux limits to CM2)
```
`cm3-coupling` adds `p2` for use as a minimum ice-thickness. [`8fad768`](https://github.com/ACCESS-NRI/Icepack/commit/8fad768ce400536904f376376e91c698a82882ba#diff-038f9d998c813a8fe204ed47bdb6f4a7e643d60ef13f230775c4a7590c721a8e) on `main` removes `Tocnfrz`, replacing it with `Tf` (provided as an input from CICE). Main adds `rhosnew`. [`05ac0ec`](https://github.com/ACCESS-NRI/Icepack/commit/05ac0ec3ea666080eed36e67f6cf8ce1255b243f#diff-038f9d998c813a8fe204ed47bdb6f4a7e643d60ef13f230775c4a7590c721a8e) on `main` adds the line 
```
use icepack_tracers,    only: ncat, nilyr, nslyr, nblyr, ntrcr, nbtrcr, n_aero
```
and removes these parameters from subroutine arguments.

Keep the changes from both branches, i.e:
```fortran
      use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny, p2
      use icepack_parameters, only: Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, rhoi
      use icepack_parameters, only: rhosi, sk_l, hs_ssl, min_salin, rsnw_fall, rhosnew
      use icepack_tracers,    only: ncat, nilyr, nslyr, nblyr, ntrcr, nbtrcr, n_aero
```

</details>


---
# Additional changes required after resolving merge conflicts
Some additional small changes were needed to get the model to build and run:

<details>

### Deprecated zsalinity
[f5e093f](https://github.com/ACCESS-NRI/Icepack/commit/f5e093f5148554674079d5c7fc0702a41b81f744#diff-05b989e99e5021cd49973064e5e310090c8562a3a8ee211c721fd7f3f40f0ccf) on `main` deprecated `zsalinity`. 

One `solve_zsal` flag remained after the rebase due to an indentation change in [b40315a](https://github.com/ACCESS-NRI/Icepack/commit/b40315a5b32ce180314f3c5c58caf001d3f9db34), causing the build to fail.

```fortran
         if (solve_zsal) sw_dtemp = p1  ! lower tolerance with dynamic salinity
```

This line should be removed to match the changes in main
</details>



